### PR TITLE
get_remote_hash: don't use regex

### DIFF
--- a/autoload/vital/_vim_gita/VCS/Git/Core.vim
+++ b/autoload/vital/_vim_gita/VCS/Git/Core.vim
@@ -140,18 +140,18 @@ function! s:get_local_hash(repository, branch) abort " {{{
   return s:_readline(filename)
 endfunction " }}}
 function! s:get_remote_hash(repository, remote, branch) abort " {{{
-  let filename = s:Path.join(a:repository, 'refs', 'remotes', a:remote, a:branch)
+  let packed_ref = s:Path.join('refs', 'remote', a:remote, a:branch)
+  let filename = s:Path.join(a:repository, packed_ref)
   let hash = s:_readline(filename)
   if empty(hash)
     " sometime the file is missing
     let filename = s:Path.join(a:repository, 'packed-refs')
-    let packed_refs = join(s:_readfile(filename), "\n")
-    " Note:
-    "   Vim document said '.' does not hit a new line but it is a LIE.
-    "   And the behavior of regexpengine=1 is quite annoying thus the
-    "   following discusting regex is required...
-    let pattern = printf('\v(\w|\s)*\ze\srefs/remotes/%s/%s', a:remote, a:branch)
-    let hash = matchstr(packed_refs, pattern)
+    for ref in s:_readfile(filename)
+      let words = split(ref)
+      if words[1] == packed_ref
+        return words[0]
+      endif
+    endfor
   endif
   return hash
 endfunction " }}}


### PR DESCRIPTION
On the nvim repository, which has many, many remote references, whenever I edit a file, run `:Gita status`, then `<<` or `>>` to stage or unstage changes, it takes over ten seconds to complete! I narrowed it down to this line:

``` vim
let hash = matchstr(packed_refs, pattern)
```

This happens because `.git/packed-refs` (`packed_refs`) is huge and `pattern` is complex. We can much more efficiently just split the string and check if the second item matches `'refs/remote/{a:remote}/{a:branch}'`. With this PR, this function only takes one second to run. 

A much better improvement would be to use `grep` (takes 0.03 seconds), but I'm not sure of the best way to do this. There is `'grepprg'`, but how to parse/interpret it isn't obvious to me.

PS: Since I'm staging local changes, I'm not sure why `s:get_local_hash` isn't called instead, but this works anyway.
