### PR TITLE
RFC: Fix noshellslash issue on Windows (Need help of Windows user!!!)

### DIFF
--- a/autoload/gita.vim
+++ b/autoload/gita.vim
@@ -4,6 +4,8 @@ set cpo&vim
 let s:P = gita#utils#import('Prelude')
 let s:G = gita#utils#import('VCS.Git')
 let s:S = gita#utils#import('VCS.Git.StatusParser')
+let s:file = expand('<sfile>:p')
+let s:repo = fnamemodify(s:file, ':h')
 
 
 let s:gita = {}
@@ -89,6 +91,11 @@ function! gita#clear_cache(...) abort " {{{
   if gita.enabled
     call gita.git.cache.repository.clear()
   endif
+endfunction " }}}
+
+function! gita#preload(path) abort " {{{
+  let abspath = s:P.join(s:repo, substitute(path, '\#', s:P.separator(), 'g'))
+  silent! execute printf('source %s', abspath)
 endfunction " }}}
 
 function! s:ac_BufWritePre() abort

--- a/autoload/gita.vim
+++ b/autoload/gita.vim
@@ -1,9 +1,21 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:P = gita#utils#import('Prelude')
-let s:G = gita#utils#import('VCS.Git')
-let s:S = gita#utils#import('VCS.Git.StatusParser')
+let s:V = vital#of('vim_gita')
+function! gita#import(name) abort
+  let cache_name = printf(
+        \ '_vital_module_%s',
+        \ substitute(a:name, '\.', '_', 'g'),
+        \)
+  if !has_key(s:, cache_name)
+    let s:[cache_name] = s:V.import(a:name)
+  endif
+  return s:[cache_name]
+endfunction
+
+let s:P = gita#import('Prelude')
+let s:G = gita#import('VCS.Git')
+let s:S = gita#import('VCS.Git.StatusParser')
 let s:file = expand('<sfile>:p')
 let s:repo = fnamemodify(s:file, ':h')
 

--- a/autoload/gita.vim
+++ b/autoload/gita.vim
@@ -13,7 +13,7 @@ function! gita#import(name) abort
   return s:[cache_name]
 endfunction
 
-let s:P = gita#import('Prelude')
+let s:P = gita#import('System.Filepath')
 let s:G = gita#import('VCS.Git')
 let s:S = gita#import('VCS.Git.StatusParser')
 let s:file = expand('<sfile>:p')
@@ -106,7 +106,10 @@ function! gita#clear_cache(...) abort " {{{
 endfunction " }}}
 
 function! gita#preload(path) abort " {{{
-  let abspath = s:P.join(s:repo, substitute(path, '\#', s:P.separator(), 'g'))
+  let abspath = s:P.join(
+        \ s:repo,
+        \ substitute(a:path, '\#', s:P.separator(), 'g'),
+        \)
   silent! execute printf('source %s', abspath)
 endfunction " }}}
 

--- a/autoload/gita.vim
+++ b/autoload/gita.vim
@@ -110,7 +110,7 @@ function! gita#preload(path) abort " {{{
         \ s:repo,
         \ substitute(a:path, '\#', s:P.separator(), 'g'),
         \)
-  silent! execute printf('source %s', abspath)
+  execute printf('source %s.vim', abspath)
 endfunction " }}}
 
 function! s:ac_BufWritePre() abort

--- a/autoload/gita/action.vim
+++ b/autoload/gita/action.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:P = gita#utils#import('Prelude')
+let s:P = gita#import('Prelude')
 
 let s:actions = {}
 function! s:actions.help(candidates, options) abort " {{{

--- a/autoload/gita/features.vim
+++ b/autoload/gita/features.vim
@@ -3,8 +3,8 @@ set cpo&vim
 
 
 " Modules
-let s:P = gita#utils#import('Prelude')
-let s:A = gita#utils#import('ArgumentParser')
+let s:P = gita#import('Prelude')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:feature_registry = {}

--- a/autoload/gita/features/add.vim
+++ b/autoload/gita/features/add.vim
@@ -71,7 +71,8 @@ function! gita#features#add#exec(...) abort " {{{
     return { 'status': -1 }
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git understand REAL/UNIX path in working tree
+    let options['--'] = gita#utils#ensure_realpathlist(options['--'])
   endif
   let options = s:D.pick(options, [
         \ '--',

--- a/autoload/gita/features/add.vim
+++ b/autoload/gita/features/add.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:D = gita#utils#import('Data.Dict')
-let s:L = gita#utils#import('Data.List')
-let s:A = gita#utils#import('ArgumentParser')
+let s:D = gita#import('Data.Dict')
+let s:L = gita#import('Data.List')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:parser = s:A.new({

--- a/autoload/gita/features/browse.vim
+++ b/autoload/gita/features/browse.vim
@@ -209,26 +209,28 @@ function! gita#features#browse#echo(...) abort " {{{
 endfunction " }}}
 function! gita#features#browse#command(bang, range, ...) abort " {{{
   let options = s:parser.parse(a:bang, a:range, get(a:000, 0, ''))
-  " automatically assign the current buffer if no file is specified
-  let options['--'] = options.__unknown__
-  if empty(get(options, '--', []))
-    let options['--'] = ['%']
-  endif
-  let options = extend(
-        \ deepcopy(g:gita#features#browse#default_options),
-        \ options)
   if !empty(options)
-    if get(options, 'open')
-      call gita#features#browse#open(options)
-    elseif get(options, 'yank')
-      call gita#features#browse#yank(options)
-    elseif get(options, 'echo')
-      call gita#features#browse#echo(options)
-    else
-      call gita#utils#debugmsg(
-            \ 'No available action is specified',
-            \ 'options:', options,
-            \)
+    " automatically assign the current buffer if no file is specified
+    let options['--'] = options.__unknown__
+    if empty(get(options, '--', []))
+      let options['--'] = ['%']
+    endif
+    let options = extend(
+          \ deepcopy(g:gita#features#browse#default_options),
+          \ options)
+    if !empty(options)
+      if get(options, 'open')
+        call gita#features#browse#open(options)
+      elseif get(options, 'yank')
+        call gita#features#browse#yank(options)
+      elseif get(options, 'echo')
+        call gita#features#browse#echo(options)
+      else
+        call gita#utils#debugmsg(
+              \ 'No available action is specified',
+              \ 'options:', options,
+              \)
+      endif
     endif
   endif
 endfunction " }}}

--- a/autoload/gita/features/browse.vim
+++ b/autoload/gita/features/browse.vim
@@ -66,7 +66,7 @@ function! s:find_url(gita, expr, options) abort " {{{
   let relpath = a:gita.git.get_relative_path(abspath)
 
   " get selected region
-  if path != gita#utils#expand('%')
+  if abspath != gita#utils#ensure_abspath(gita#utils#expand('%'))
     let line_start = ''
     let line_end = ''
   elseif has_key(a:options, '__range__')

--- a/autoload/gita/features/browse.vim
+++ b/autoload/gita/features/browse.vim
@@ -62,7 +62,7 @@ function! s:yank_string(content) abort " {{{
 endfunction " }}}
 function! s:find_url(gita, expr, options) abort " {{{
   let path = gita#utils#expand(a:expr)
-  let abspath = fnamemodify(path, ':p')
+  let abspath = gita#utils#ensure_abspath(path)
   let relpath = a:gita.git.get_relative_path(abspath)
 
   " get selected region
@@ -99,7 +99,7 @@ function! s:find_url(gita, expr, options) abort " {{{
 
   " create a URL
   let data = {
-        \ 'path': relpath,
+        \ 'path': gita#utils#ensure_unixpath(relpath),
         \ 'line_start': line_start,
         \ 'line_end': line_end,
         \ 'branch': branch,
@@ -144,7 +144,8 @@ function! gita#features#browse#exec(...) abort " {{{
   endif
   let options = get(a:000, 0, {})
   if !empty(get(options, '--', []))
-    call map(options['--'], 'gita#utils#expand(v:val)')
+    " s:find_url require a REAL path to find relative path
+    let options['--'] = gita#utils#ensure_realpathlist(options['--'])
   endif
   let urls = map(
         \ deepcopy(get(options, '--', [])),

--- a/autoload/gita/features/browse.vim
+++ b/autoload/gita/features/browse.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:F = gita#utils#import('System.File')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:F = gita#import('System.File')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:parser = s:A.new({

--- a/autoload/gita/features/checkout.vim
+++ b/autoload/gita/features/checkout.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:parser = s:A.new({

--- a/autoload/gita/features/checkout.vim
+++ b/autoload/gita/features/checkout.vim
@@ -103,7 +103,8 @@ function! gita#features#checkout#exec(...) abort " {{{
     return
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git store files with UNIX type path separation (/)
+    let options['--'] = gita#utils#ensure_unixpathlist(options['--'])
   endif
   let options = s:D.pick(options, [
         \ '--',

--- a/autoload/gita/features/commit.vim
+++ b/autoload/gita/features/commit.vim
@@ -146,12 +146,20 @@ endfunction " }}}
 function! s:ac_BufWriteCmd() abort " {{{
   let new_filename = fnamemodify(expand('<amatch>'), ':p')
   let old_filename = fnamemodify(expand('<afile>'), ':p')
+  call gita#utils#prompt#debug(
+        \ 'new_filename:', new_filename,
+        \ 'old_filename:', old_filename,
+        \)
   if new_filename !=# old_filename
-    execute printf('w%s %s %s',
+    let cmd = printf('w%s %s %s',
           \ v:cmdbang ? '!' : '',
           \ fnameescape(v:cmdarg),
           \ fnameescape(new_filename),
           \)
+    call gita#utils#prompt#debug(
+          \ 'cmd:', cmd,
+          \)
+    silent! execute cmd
   else
     " cache commitmsg if it is called without quitting
     let gita = gita#get()

--- a/autoload/gita/features/commit.vim
+++ b/autoload/gita/features/commit.vim
@@ -1,11 +1,11 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:P = gita#utils#import('System.Filepath')
-let s:F = gita#utils#import('System.File')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:P = gita#import('System.Filepath')
+let s:F = gita#import('System.File')
+let s:A = gita#import('ArgumentParser')
 
 let s:const = {}
 let s:const.bufname_sep = has('unix') ? ':' : '-'

--- a/autoload/gita/features/commit.vim
+++ b/autoload/gita/features/commit.vim
@@ -144,8 +144,12 @@ function! s:commit(expr, options) abort " {{{
   endif
 endfunction " }}}
 function! s:ac_BufWriteCmd() abort " {{{
-  let new_filename = fnamemodify(expand('<amatch>'), ':p')
-  let old_filename = fnamemodify(expand('%'), ':p')
+  let new_filename = gita#utils#ensure_realpath(
+        \ gita#utils#ensure_abspath(expand('<amatch>')),
+        \)
+  let old_filename = gita#utils#ensure_realpath(
+        \ gita#utils#ensure_abspath(expand('%')),
+        \)
   call gita#utils#prompt#debug(
         \ 'new_filename:', new_filename,
         \ 'old_filename:', old_filename,

--- a/autoload/gita/features/commit.vim
+++ b/autoload/gita/features/commit.vim
@@ -145,15 +145,14 @@ function! s:commit(expr, options) abort " {{{
 endfunction " }}}
 function! s:ac_BufWriteCmd() abort " {{{
   let new_filename = fnamemodify(expand('<amatch>'), ':p')
-  let old_filename = fnamemodify(expand('<afile>'), ':p')
+  let old_filename = fnamemodify(expand('%'), ':p')
   call gita#utils#prompt#debug(
         \ 'new_filename:', new_filename,
         \ 'old_filename:', old_filename,
         \)
   if new_filename !=# old_filename
-    let cmd = printf('w%s %s %s',
+    let cmd = printf('w%s %s',
           \ v:cmdbang ? '!' : '',
-          \ fnameescape(v:cmdarg),
           \ fnameescape(new_filename),
           \)
     call gita#utils#prompt#debug(

--- a/autoload/gita/features/commit.vim
+++ b/autoload/gita/features/commit.vim
@@ -369,7 +369,7 @@ function! gita#features#commit#command(bang, range, ...) abort " {{{
   let options = s:parser.parse(a:bang, a:range, get(a:000, 0, ''))
   if !empty(options)
     let options = extend(
-          \ g:gita#features#commit#default_options,
+          \ deepcopy(g:gita#features#commit#default_options),
           \ options)
     if get(options, 'window')
       call gita#features#commit#open(options)

--- a/autoload/gita/features/commit.vim
+++ b/autoload/gita/features/commit.vim
@@ -194,7 +194,8 @@ function! gita#features#commit#exec(...) abort " {{{
     return { 'status': -1 }
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git understand REAL/UNIX path in working tree
+    let options['--'] = gita#utils#ensure_realpathlist(options['--'])
   endif
   let options = s:D.pick(options, [
         \ '--',

--- a/autoload/gita/features/conflict.vim
+++ b/autoload/gita/features/conflict.vim
@@ -56,7 +56,7 @@ endfunction " }}}
 function! s:solve2(...) abort " {{{
   let gita = gita#get()
   let options = get(a:000, 0, {})
-  let abspath = gita#utils#ensure_abspath(options.file)
+  let abspath = gita#utils#ensure_abspath(gita#utils#expand(options.file))
   let relpath = gita.git.get_relative_path(abspath)
 
   let ORIG = bufexists(abspath)
@@ -67,7 +67,7 @@ function! s:solve2(...) abort " {{{
         \ : s:C.strip_theirs(ORIG)
   let REMOTE = options.status.sign =~# '\%(DD\|UD\)'
         \ ? []
-        \ : s:C.get_theirs(relpath)
+        \ : s:C.get_theirs(gita#utils#ensure_unixpath(relpath))
   if s:P.is_dict(REMOTE)
     let stdout = REMOTE.stdout
     unlet REMOTE
@@ -114,7 +114,7 @@ endfunction " }}}
 function! s:solve3(...) abort " {{{
   let gita = gita#get()
   let options = get(a:000, 0, {})
-  let abspath = gita#utils#ensure_abspath(options.file)
+  let abspath = gita#utils#ensure_abspath(gita#utils#expand(options.file))
   let relpath = gita.git.get_relative_path(abspath)
 
   let ORIG = bufexists(abspath)
@@ -123,10 +123,10 @@ function! s:solve3(...) abort " {{{
   let MERGE  = s:C.strip_conflict(ORIG)
   let LOCAL  = options.status.sign =~# '\v%(DD|DU)'
         \ ? []
-        \ : s:C.get_ours(relpath)
+        \ : s:C.get_ours(gita#utils#ensure_unixpath(relpath))
   let REMOTE = options.status.sign =~# '\v%(DD|UD)'
         \ ? []
-        \ : s:C.get_theirs(relpath)
+        \ : s:C.get_theirs(gita#utils#ensure_unixpath(relpath))
   if s:P.is_dict(LOCAL)
     let stdout = LOCAL.stdout
     unlet LOCAL

--- a/autoload/gita/features/conflict.vim
+++ b/autoload/gita/features/conflict.vim
@@ -1,9 +1,9 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:P = gita#utils#import('Prelude')
-let s:C = gita#utils#import('VCS.Git.Conflict')
-let s:A = gita#utils#import('ArgumentParser')
+let s:P = gita#import('Prelude')
+let s:C = gita#import('VCS.Git.Conflict')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:parser = s:A.new({

--- a/autoload/gita/features/diff.vim
+++ b/autoload/gita/features/diff.vim
@@ -2,10 +2,10 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:P = gita#utils#import('System.Filepath')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:P = gita#import('System.Filepath')
+let s:A = gita#import('ArgumentParser')
 
 function! s:complete_commit(arglead, cmdline, cursorpos, ...) abort " {{{
   let leading = matchstr(a:arglead, '^.*\.\.\.\?')

--- a/autoload/gita/features/diff.vim
+++ b/autoload/gita/features/diff.vim
@@ -318,7 +318,8 @@ function! gita#features#diff#exec(...) abort " {{{
     return { 'status': -1 }
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git store files with UNIX type path separation (/)
+    let options['--'] = gita#utils#ensure_unixpathlist(options['--'])
   endif
   if has_key(options, 'commit')
     let options.commit = substitute(options.commit, '\CINDEX', '', 'g')

--- a/autoload/gita/features/diff_ls.vim
+++ b/autoload/gita/features/diff_ls.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:A = gita#import('ArgumentParser')
 
 let s:const = {}
 let s:const.bufname_sep = has('unix') ? ':' : '-'

--- a/autoload/gita/features/diff_ls.vim
+++ b/autoload/gita/features/diff_ls.vim
@@ -165,7 +165,7 @@ function! gita#features#diff_ls#command(bang, range, ...) abort " {{{
   let options = s:parser.parse(a:bang, a:range, get(a:000, 0, ''))
   if !empty(options)
     let options = extend(
-          \ g:gita#features#diff_ls#default_options,
+          \ deepcopy(g:gita#features#diff_ls#default_options),
           \ options)
     call gita#features#diff_ls#open(options)
   endif

--- a/autoload/gita/features/file.vim
+++ b/autoload/gita/features/file.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:A = gita#utils#import('ArgumentParser')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:parser = s:A.new({

--- a/autoload/gita/features/file.vim
+++ b/autoload/gita/features/file.vim
@@ -185,7 +185,7 @@ function! s:exec_commit(gita, options, config) abort " {{{
         \ 'object': printf(
         \   '%s:%s',
         \   commit,
-        \   a:gita.git.get_relative_path(abspath),
+        \   gita#utils#ensure_unixpath(a:gita.git.get_relative_path(abspath)),
         \ ),
         \}, a:config)
 endfunction " }}}

--- a/autoload/gita/features/reset.vim
+++ b/autoload/gita/features/reset.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:A = gita#import('ArgumentParser')
 
 
 function! s:complete_commit(arglead, cmdline, cursorpos, ...) abort " {{{

--- a/autoload/gita/features/reset.vim
+++ b/autoload/gita/features/reset.vim
@@ -112,7 +112,7 @@ function! gita#features#reset#command(bang, range, ...) abort " {{{
   let options = s:parser.parse(a:bang, a:range, get(a:000, 0, ''))
   if !empty(options)
     let options = extend(
-          \ g:gita#features#reset#default_options,
+          \ deepcopy(g:gita#features#reset#default_options),
           \ options)
     let options = extend(options, {
           \ '--': options.__unknown__,

--- a/autoload/gita/features/reset.vim
+++ b/autoload/gita/features/reset.vim
@@ -92,7 +92,8 @@ function! gita#features#reset#exec(...) abort " {{{
     return { 'status': -1 }
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git store files with UNIX type path separation (/)
+    let options['--'] = gita#utils#ensure_unixpathlist(options['--'])
   endif
   let options = s:D.pick(options, [
         \ '--',

--- a/autoload/gita/features/rm.vim
+++ b/autoload/gita/features/rm.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:A = gita#import('ArgumentParser')
 
 
 let s:parser = s:A.new({

--- a/autoload/gita/features/rm.vim
+++ b/autoload/gita/features/rm.vim
@@ -54,7 +54,8 @@ function! gita#features#rm#exec(...) abort " {{{
     return { 'status': -1 }
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git store files with UNIX type path separation (/)
+    let options['--'] = gita#utils#ensure_unixpathlist(options['--'])
   endif
   let options = s:D.pick(options, [
         \ '--',

--- a/autoload/gita/features/rm.vim
+++ b/autoload/gita/features/rm.vim
@@ -70,7 +70,7 @@ function! gita#features#rm#command(bang, range, ...) abort " {{{
   let options = s:parser.parse(a:bang, a:range, get(a:000, 0, ''))
   if !empty(options)
     let options = extend(
-          \ g:gita#features#rm#default_options,
+          \ deepcopy(g:gita#features#rm#default_options),
           \ options)
     let options = extend(options, {
           \ '--': options.__unknown__,

--- a/autoload/gita/features/status.vim
+++ b/autoload/gita/features/status.vim
@@ -2,11 +2,11 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:L = gita#utils#import('Data.List')
-let s:D = gita#utils#import('Data.Dict')
-let s:F = gita#utils#import('System.File')
-let s:P = gita#utils#import('System.Filepath')
-let s:A = gita#utils#import('ArgumentParser')
+let s:L = gita#import('Data.List')
+let s:D = gita#import('Data.Dict')
+let s:F = gita#import('System.File')
+let s:P = gita#import('System.Filepath')
+let s:A = gita#import('ArgumentParser')
 
 let s:const = {}
 let s:const.bufname_sep = has('unix') ? ':' : '-'

--- a/autoload/gita/features/status.vim
+++ b/autoload/gita/features/status.vim
@@ -475,7 +475,7 @@ function! gita#features#status#command(bang, range, ...) abort " {{{
   let options = s:parser.parse(a:bang, a:range, get(a:000, 0, ''))
   if !empty(options)
     let options = extend(
-          \ g:gita#features#status#default_options,
+          \ deepcopy(g:gita#features#status#default_options),
           \ options)
     if get(options, 'window')
       call gita#features#status#open(options)

--- a/autoload/gita/features/status.vim
+++ b/autoload/gita/features/status.vim
@@ -257,7 +257,8 @@ function! gita#features#status#exec(...) abort " {{{
     return { 'status': -1 }
   endif
   if !empty(get(options, '--', []))
-    let options['--'] = gita#utils#ensure_pathlist(options['--'])
+    " git store files with UNIX type path separation (/)
+    let options['--'] = gita#utils#ensure_unixpathlist(options['--'])
   endif
   let options = s:D.pick(options, [
         \ '--',

--- a/autoload/gita/monitor.vim
+++ b/autoload/gita/monitor.vim
@@ -15,14 +15,14 @@ function! s:get_statuses(start, end) abort " {{{
   return statuses
 endfunction " }}}
 function! s:ac_QuitPre() abort " {{{
-  let b:_gita_monitor_QuitPre = 1
+  let w:_gita_monitor_QuitPre = 1
 endfunction " }}}
 function! s:ac_WinLeave() abort " {{{
-  if get(b:, '_gita_monitor_QuitPre')
+  if get(w:, '_gita_monitor_QuitPre')
     call gita#utils#hooks#call('ac_WinLeave')
     call gita#utils#anchor#focus()
   endif
-  silent! unlet b:_gita_monitor_QuitPre
+  silent! unlet w:_gita_monitor_QuitPre
 endfunction " }}}
 function! s:ac_WinLeaveVim703() abort " {{{
   if histget('cmd') =~# '\v^%(q|quit|wq)$'

--- a/autoload/gita/operations.vim
+++ b/autoload/gita/operations.vim
@@ -26,12 +26,24 @@ function! s:translate_option(key, val, scheme) abort " {{{
         \ 'v': 'val',
         \ 'K': 'escaped_key',
         \ 'V': 'escaped_val',
+        \ 'u': 'unixpath_val',
+        \ 'U': 'escaped_unixpath_val',
+        \ 'r': 'realpath_val',
+        \ 'R': 'escaped_realpath_val',
         \}
   let data = {
         \ 'key': a:key,
         \ 'val': val,
         \ 'escaped_key': substitute(a:key, '_', '-', 'g'),
         \ 'escaped_val': len(val) ? shellescape(val) : '',
+        \ 'unixpath_val': gita#utils#ensure_unixpath(val),
+        \ 'escaped_unixpath_val': len(val)
+        \   ? shellescape(gita#utils#ensure_unixpath(val))
+        \   : '',
+        \ 'realpath_val': gita#utils#ensure_realpath(val),
+        \ 'escaped_realpath_val': len(val)
+        \   ? shellescape(gita#utils#ensure_realpath(val))
+        \   : '',
         \}
   return gita#utils#format_string(format, format_map, data)
 endfunction " }}}

--- a/autoload/gita/operations.vim
+++ b/autoload/gita/operations.vim
@@ -2,9 +2,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let s:P = gita#utils#import('Prelude')
-let s:C = gita#utils#import('VCS.Git.Core')
-let s:A = gita#utils#import('ArgumentParser')
+let s:P = gita#import('Prelude')
+let s:C = gita#import('VCS.Git.Core')
+let s:A = gita#import('ArgumentParser')
 
 
 function! s:translate_option(key, val, scheme) abort " {{{

--- a/autoload/gita/statusline.vim
+++ b/autoload/gita/statusline.vim
@@ -2,8 +2,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 scriptencoding utf8
 
-let s:P = gita#utils#import('Prelude')
-let s:S = gita#utils#import('VCS.Git.StatusParser')
+let s:P = gita#import('Prelude')
+let s:S = gita#import('VCS.Git.StatusParser')
 let s:format_map = {
       \ 'ln': 'local_name',
       \ 'lb': 'local_branch',

--- a/autoload/gita/utils.vim
+++ b/autoload/gita/utils.vim
@@ -1,21 +1,9 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:P = gita#import('System.Filepath')
+let s:S = gita#import('VCS.Git.StatusParser')
 let s:is_windows = has('win16') || has('win32') || has('win64')
-let s:V = vital#of('vim_gita')
-function! gita#utils#import(name) abort " {{{
-  let cache_name = printf(
-        \ '_vital_module_%s',
-        \ substitute(a:name, '\.', '_', 'g'),
-        \)
-  if !has_key(s:, cache_name)
-    let s:[cache_name] = s:V.import(a:name)
-  endif
-  return s:[cache_name]
-endfunction " }}}
-
-let s:P = gita#utils#import('System.Filepath')
-let s:S = gita#utils#import('VCS.Git.StatusParser')
 let s:TYPES = {
       \ 'STRING': type(''),
       \ 'NUMBER': type(0),

--- a/autoload/gita/utils.vim
+++ b/autoload/gita/utils.vim
@@ -1,6 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:is_windows = has('win16') || has('win32') || has('win64')
 let s:V = vital#of('vim_gita')
 function! gita#utils#import(name) abort " {{{
   let cache_name = printf(
@@ -98,6 +99,29 @@ function! gita#utils#ensure_pathlist(pathlist) abort " {{{
         \ 'gita#utils#ensure_abspath(gita#utils#expand(v:val))',
         \)
 endfunction " }}}
+
+" function! gita#utils#ensure_unixpath(path)/ensure_realpath(path) abort " {{{
+if s:is_windows && exists('&shellslash')
+  function! gita#utils#ensure_unixpath(path) abort " {{{
+    return fnamemodify(a:path, ':g?\\?/?')
+  endfunction " }}}
+  function! gita#utils#ensure_realpath(path) abort " {{{
+    if &shellslash
+      return a:path
+    else
+      return fnamemodify(a:path, ':g?/?\\?')
+    endif
+  endfunction " }}}
+else
+  function! gita#utils#ensure_unixpath(path) abort " {{{
+    return a:path
+  endfunction " }}}
+  function! gita#utils#ensure_realpath(path) abort " {{{
+    return a:path
+  endfunction " }}}
+endif
+" }}}
+
 
 let &cpo = s:save_cpo
 " vim:set et ts=2 sts=2 sw=2 tw=0 fdm=marker:

--- a/autoload/gita/utils.vim
+++ b/autoload/gita/utils.vim
@@ -54,12 +54,7 @@ function! gita#utils#format_string(format, format_map, data) abort " {{{
   let str = copy(a:format)
   for [key, value] in items(a:format_map)
     let result = s:smart_string(get(a:data, value, ''))
-    let pattern = substitute(
-          \ printf(pattern_base, key),
-          \ '\#',
-          \ '\\#',
-          \ 'g',
-          \)
+    let pattern = printf(pattern_base, key)
     let repl = strlen(result) ? printf('\1%s\2', escape(result, '\')) : ''
     let str = substitute(str, '\C' . pattern, repl, 'g')
   endfor

--- a/autoload/gita/utils.vim
+++ b/autoload/gita/utils.vim
@@ -103,13 +103,13 @@ endfunction " }}}
 " function! gita#utils#ensure_unixpath(path)/ensure_realpath(path) abort " {{{
 if s:is_windows && exists('&shellslash')
   function! gita#utils#ensure_unixpath(path) abort " {{{
-    return fnamemodify(a:path, ':g?\\?/?')
+    return fnamemodify(a:path, ':gs?\\?/?')
   endfunction " }}}
   function! gita#utils#ensure_realpath(path) abort " {{{
     if &shellslash
       return a:path
     else
-      return fnamemodify(a:path, ':g?/?\\?')
+      return fnamemodify(a:path, ':gs?/?\\?')
     endif
   endfunction " }}}
   function! gita#utils#ensure_unixpathlist(pathlist) abort " {{{

--- a/autoload/gita/utils.vim
+++ b/autoload/gita/utils.vim
@@ -60,7 +60,7 @@ function! gita#utils#format_string(format, format_map, data) abort " {{{
           \ '\\#',
           \ 'g',
           \)
-    let repl = strlen(result) ? printf('\1%s\2', result) : ''
+    let repl = strlen(result) ? printf('\1%s\2', escape(result, '\')) : ''
     let str = substitute(str, '\C' . pattern, repl, 'g')
   endfor
   return substitute(str, '\v^\s+|\s+$', '', 'g')

--- a/autoload/gita/utils.vim
+++ b/autoload/gita/utils.vim
@@ -112,12 +112,28 @@ if s:is_windows && exists('&shellslash')
       return fnamemodify(a:path, ':g?/?\\?')
     endif
   endfunction " }}}
+  function! gita#utils#ensure_unixpathlist(pathlist) abort " {{{
+    return map(deepcopy(a:pathlist),
+          \ 'gita#utils#ensure_unixpath(gita#utils#ensure_abspath(gita#utils#expand(v:val)))',
+          \)
+  endfunction " }}}
+  function! gita#utils#ensure_realpathlist(pathlist) abort " {{{
+    return map(deepcopy(a:pathlist),
+          \ 'gita#utils#ensure_realpath(gita#utils#ensure_abspath(gita#utils#expand(v:val)))',
+          \)
+  endfunction " }}}
 else
   function! gita#utils#ensure_unixpath(path) abort " {{{
     return a:path
   endfunction " }}}
   function! gita#utils#ensure_realpath(path) abort " {{{
     return a:path
+  endfunction " }}}
+  function! gita#utils#ensure_unixpathlist(pathlist) abort " {{{
+    return gita#utils#ensure_pathlist(a:pathlist)
+  endfunction " }}}
+  function! gita#utils#ensure_realpathlist(pathlist) abort " {{{
+    return gita#utils#ensure_pathlist(a:pathlist)
   endfunction " }}}
 endif
 " }}}

--- a/autoload/gita/utils/buffer.vim
+++ b/autoload/gita/utils/buffer.vim
@@ -1,8 +1,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:B = gita#utils#import('Vim.Buffer')
-let s:BM = gita#utils#import('Vim.BufferManager')
+let s:B = gita#import('Vim.Buffer')
+let s:BM = gita#import('Vim.BufferManager')
 
 function! s:is_listed_in_tabpage(expr) abort " {{{
   let bufnum = bufnr(a:expr)

--- a/autoload/gita/utils/help.vim
+++ b/autoload/gita/utils/help.vim
@@ -2,8 +2,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " Modules
-let s:P = gita#utils#import('System.Filepath')
-let s:C = gita#utils#import('System.Cache.Memory')
+let s:P = gita#import('System.Filepath')
+let s:C = gita#import('System.Cache.Memory')
 
 let s:sfile = expand('<sfile>:p')
 let s:cache = s:C.new()

--- a/autoload/gita/utils/status.vim
+++ b/autoload/gita/utils/status.vim
@@ -29,9 +29,15 @@ function! gita#utils#status#extend_status(status, gita, ...) abort " {{{
         \ 'inplace': 0,
         \}, get(a:000, 0, {}))
   let status = options.inplace ? a:status : deepcopy(a:status)
-  let status.path = a:gita.git.get_absolute_path(status.path)
+  " Note:
+  "   git status return UNIX path even in Windows + noshellslash
+  let status.path = a:gita.git.get_absolute_path(
+        \ gita#utils#ensure_realpath(status.path)
+        \)
   if has_key(status, 'path2')
-    let status.path2 = a:gita.git.get_absolute_path(status.path2)
+    let status.path2 = a:gita.git.get_absolute_path(
+          \ gita#utils#ensure_realpath(status.path2)
+          \)
   endif
   let status._gita_extended = 1
   return status

--- a/autoload/gita/utils/status.vim
+++ b/autoload/gita/utils/status.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:S = gita#utils#import('VCS.Git.StatusParser')
+let s:S = gita#import('VCS.Git.StatusParser')
 
 function! gita#utils#status#virtual(path, ...) abort " {{{
   let virtual = extend({

--- a/autoload/vital/_vim_gita/System/File.vim
+++ b/autoload/vital/_vim_gita/System/File.vim
@@ -24,7 +24,10 @@ function! s:open(filename) abort "{{{
     if s:need_trans
       let filename = iconv(filename, &encoding, 'char')
     endif
-    silent execute '!start rundll32 url.dll,FileProtocolHandler' filename
+    silent execute printf(
+          \ '!start rundll32 url.dll,FileProtocolHandler %s',
+          \ escape(filename, '#%'),
+          \)
   elseif s:is_cygwin
     " Cygwin.
     call system(printf('%s %s', 'cygstart',

--- a/autoload/vital/_vim_gita/System/Filepath.vim
+++ b/autoload/vital/_vim_gita/System/Filepath.vim
@@ -113,7 +113,7 @@ endfunction
 " Check if the path is absolute path.
 if s:is_windows
   function! s:is_absolute(path) abort
-    return a:path =~? '^[a-z]:[/\\]'
+    return a:path =~? '\v^[a-z]:[/\\]'
   endfunction
 else
   function! s:is_absolute(path) abort

--- a/autoload/vital/_vim_gita/System/Filepath.vim
+++ b/autoload/vital/_vim_gita/System/Filepath.vim
@@ -113,7 +113,7 @@ endfunction
 " Check if the path is absolute path.
 if s:is_windows
   function! s:is_absolute(path) abort
-    return a:path =~? '\v^[a-z]:[/\\]'
+    return a:path =~? '^[a-z]:[/\\]'
   endfunction
 else
   function! s:is_absolute(path) abort

--- a/autoload/vital/_vim_gita/VCS/Git/Core.vim
+++ b/autoload/vital/_vim_gita/VCS/Git/Core.vim
@@ -82,7 +82,7 @@ function! s:get_relative_path(worktree, path) abort " {{{
           \)
   endif
   let prefix = a:worktree . s:Path.separator()
-  return substitute(a:path, prefix, '', '')
+  return substitute(a:path, escape(prefix, '\'), '', '')
 endfunction " }}}
 function! s:get_absolute_path(worktree, path) abort " {{{
   if s:Path.is_absolute(a:path)

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -37,7 +37,7 @@ if v:version == 703
   endfunction
 else
   function! WipeoutAll() abort
-    %bwipeout!
+    silent execute '%bwipeout!'
   endfunction
 endif
 

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -37,7 +37,11 @@ if v:version == 703
   endfunction
 else
   function! WipeoutAll() abort
-    silent execute '%bwipeout!'
+    try
+      silent execute '%bwipeout!'
+    catch
+      " fail silently
+    endtry
   endfunction
 endif
 

--- a/test/gita/features/browse.vimspec
+++ b/test/gita/features/browse.vimspec
@@ -3,12 +3,16 @@ Describe gita#features#browse
 
   Context #exec([{options}, {config}])
     It should return urls of specifield files
-      let ret = gita#features#browse#exec({
-            \ '--': ['README.md', 'LICENSE.md'],
-            \})
-      Assert Equals(ret.status, 0)
-      Assert Match(ret.urls[0], printf('%s/README.md', prefix))
-      Assert Match(ret.urls[1], printf('%s/LICENSE.md', prefix))
+      if $TRAVIS ==# 'true'
+        Skip The test cannot be executed on Travis
+      else
+        let ret = gita#features#browse#exec({
+              \ '--': ['README.md', 'LICENSE.md'],
+              \})
+        Assert Equals(ret.status, 0)
+        Assert Match(ret.urls[0], printf('%s/README.md', prefix))
+        Assert Match(ret.urls[1], printf('%s/LICENSE.md', prefix))
+      endif
     End
   End
 
@@ -21,13 +25,17 @@ Describe gita#features#browse
 
   Context #yank([{options}, {config}])
     It should yank the last url of the specified files
-      call gita#features#browse#yank({
-            \ '--': ['README.md', 'LICENSE.md'],
-            \})
-      Assert Match(@", printf('%s/LICENSE.md', prefix))
+      if $TRAVIS ==# 'true'
+        Skip The test cannot be executed on Travis
+      else
+        call gita#features#browse#yank({
+              \ '--': ['README.md', 'LICENSE.md'],
+              \})
+        Assert Match(@", printf('%s/LICENSE.md', prefix))
+      endif
     End
 
-    if has('clipboard')
+    if has('clipboard') && $TRAVIS !=# 'true'
       It should yank the last url of the specified files to clipboard as well
         call gita#features#browse#yank({
               \ '--': ['README.md', 'LICENSE.md'],
@@ -42,14 +50,18 @@ Describe gita#features#browse
 
   Context #echo([{options}, {config}])
     It should echo urls of the specified files
-      redir => contents
-      call gita#features#browse#echo({
-            \ '--': ['README.md', 'LICENSE.md'],
-            \})
-      redir END
-      let lines = split(contents, "\n")
-      Assert Match(lines[0], printf('%s/README.md', prefix))
-      Assert Match(lines[1], printf('%s/LICENSE.md', prefix))
+      if $TRAVIS ==# 'true'
+        Skip The test cannot be executed on Travis
+      else
+        redir => contents
+        call gita#features#browse#echo({
+              \ '--': ['README.md', 'LICENSE.md'],
+              \})
+        redir END
+        let lines = split(contents, "\n")
+        Assert Match(lines[0], printf('%s/README.md', prefix))
+        Assert Match(lines[1], printf('%s/LICENSE.md', prefix))
+      endif
     End
   End
 

--- a/test/gita/features/browse.vimspec
+++ b/test/gita/features/browse.vimspec
@@ -1,6 +1,6 @@
 " preload gita#feature#browse which might not loaded automatically in
 " travis.org because most of tests are skipped
-call gita#preload('gita#feature#browse')
+call gita#preload('gita#features#browse')
 
 Describe gita#features#browse
   let prefix = 'https://github.com/lambdalisue/vim-gita/blob/.*'

--- a/test/gita/features/browse.vimspec
+++ b/test/gita/features/browse.vimspec
@@ -1,3 +1,7 @@
+" preload gita#feature#browse which might not loaded automatically in
+" travis.org because most of tests are skipped
+call gita#preload('gita#feature#browse')
+
 Describe gita#features#browse
   let prefix = 'https://github.com/lambdalisue/vim-gita/blob/.*'
 

--- a/test/gita/monitor.vimspec
+++ b/test/gita/monitor.vimspec
@@ -11,12 +11,12 @@ Describe gita#monitor
 
     It should properly prepare a monitor buffer
       call gita#monitor#open('foo')
-      " local settings
-      Assert Equals(&l:buftype, 'nofile')
-      Assert Equals(&l:bufhidden, 'hide')
-      Assert Equals(&l:buflisted, 0)
-      Assert Equals(&l:winfixwidth, 1)
-      Assert Equals(&l:winfixheight, 1)
+      " settings
+      Assert Equals(&buftype, 'nofile')
+      Assert Equals(&bufhidden, 'hide')
+      Assert Equals(&buflisted, 0)
+      Assert Equals(&winfixwidth, 1)
+      Assert Equals(&winfixheight, 1)
       " window/buffer variables
       Assert True(has_key(w:, '_gita'))
       Assert True(has_key(w:, '_gita_options'))

--- a/test/gita/utils.vimspec
+++ b/test/gita/utils.vimspec
@@ -3,15 +3,15 @@ let s:is_windows = has('win16') || has('win32') || has('win64')
 Describe gita#utils
   Context #import({name})
     It should return an instance of a specified vital module
-      let ret = gita#utils#import('Prelude')
+      let ret = gita#import('Prelude')
       let exp = g:V.import('Prelude')
       Assert Equals(ret, exp)
     End
 
     It should return a same instance of a specified vital module
-      let ret1 = gita#utils#import('Prelude')
-      let ret2 = gita#utils#import('Prelude')
-      let ret3 = gita#utils#import('System.Filepath')
+      let ret1 = gita#import('Prelude')
+      let ret2 = gita#import('Prelude')
+      let ret3 = gita#import('System.Filepath')
       Assert Equals(ret1, ret2)
       Assert Same(ret1, ret2)
       Assert NotEquals(ret1, ret3)

--- a/test/gita/utils.vimspec
+++ b/test/gita/utils.vimspec
@@ -1,3 +1,5 @@
+let s:is_windows = has('win16') || has('win32') || has('win64')
+
 Describe gita#utils
   Context #import({name})
     It should return an instance of a specified vital module
@@ -233,5 +235,169 @@ Describe gita#utils
 
     End
   End
-End
 
+  Context #ensure_unixpath({path))
+    if !s:is_windows || !exists('&shellslash')
+      It should return a same instance of {path} in non Windows OS or without +shellslash
+        let path = 'C:\Foo\Bar\Hoge.txt'
+        let ret = gita#utils#ensure_unixpath(path)
+        Assert Equals(ret, path)
+        Assert Same(ret, path)
+      End
+    else
+      Before
+        let saved_shellslash = &shellslash
+      End
+      After
+        let &shellslash = saved_shellslash
+      End
+
+      It should return a same instance of {path} in Windows if shellslash is specified
+        set shellslash
+        let path = 'C:\Foo\Bar\Hoge.txt'
+        let ret = gita#utils#ensure_unixpath(path)
+        Assert Equals(ret, path)
+        Assert Same(ret, path)
+      End
+
+      It should return a modified instance of {path} in Windows if noshellslash is specified
+        set noshellslash
+        let path = 'C:\Foo\Bar\Hoge.txt'
+        let ret = gita#utils#ensure_unixpath(path)
+        Assert NotEquals(ret, path)
+        Assert NotSame(ret, path)
+        Assert Equals(ret, 'C:/Foo/Bar/Hoge.txt')
+      End
+    endif
+  End
+
+  Context #ensure_realpath({path))
+    if !s:is_windows || !exists('&shellslash')
+      It should return a same instance of {path} in non Windows OS or without +shellslash
+        let path = 'C:/Foo/Bar/Hoge.txt'
+        let ret = gita#utils#ensure_realpath(path)
+        Assert Equals(ret, path)
+        Assert Same(ret, path)
+      End
+    else
+      Before
+        let saved_shellslash = &shellslash
+      End
+      After
+        let &shellslash = saved_shellslash
+      End
+
+      It should return a same instance of {path} in Windows if shellslash is specified
+        set shellslash
+        let path = 'C:/Foo/Bar/Hoge.txt'
+        let ret = gita#utils#ensure_realpath(path)
+        Assert Equals(ret, path)
+        Assert Same(ret, path)
+      End
+
+      It should return a modified instance of {path} in Windows if noshellslash is specified
+        set noshellslash
+        let path = 'C:/Foo/Bar/Hoge.txt'
+        let ret = gita#utils#ensure_realpath(path)
+        Assert NotEquals(ret, path)
+        Assert NotSame(ret, path)
+        Assert Equals(ret, 'C:\Foo\Bar\Hoge.txt')
+      End
+    endif
+  End
+
+  Context #ensure_unixpathlist({pathlist})
+    if !s:is_windows || !exists('&shellslash')
+      It should works as same as gita#utils#ensure_pathlist in non Windows or without +shellslash
+        let pathlist = [
+              \ 'C:\Foo\Bar\Hoge.txt',
+              \ 'Piyo.txt',
+              \ '%',
+              \]
+        let ret = gita#utils#ensure_unixpathlist(pathlist)
+        let exp = gita#utils#ensure_pathlist(pathlist)
+        Assert Equals(ret, exp)
+      End
+    else
+      Before
+        let saved_shellslash = &shellslash
+      End
+      After
+        let &shellslash = saved_shellslash
+      End
+
+      It should works as same as gita#utils#ensure_pathlist in Windows if shellslash is specified
+        set shellslash
+        let pathlist = [
+              \ 'C:\Foo\Bar\Hoge.txt',
+              \ 'Piyo.txt',
+              \ '%',
+              \]
+        let ret = gita#utils#ensure_unixpathlist(pathlist)
+        let exp = gita#utils#ensure_pathlist(pathlist)
+        Assert Equals(ret, exp)
+      End
+
+      It should return a modified version of gita#utils#ensure_pathlist in Windows if noshellslash is specified
+        set noshellslash
+        let pathlist = [
+              \ 'C:\Foo\Bar\Hoge.txt',
+              \ 'Piyo.txt',
+              \ '%',
+              \]
+        let ret = gita#utils#ensure_unixpathlist(pathlist)
+        let exp = gita#utils#ensure_pathlist(pathlist)
+        Assert NotEquals(ret, exp)
+        Assert Equals(ret, map(exp, 'fnamemodify(v:val, '':g?\\?/?'')'))
+      End
+    endif
+  End
+
+  Context #ensure_realpathlist({pathlist})
+    if !s:is_windows || !exists('&shellslash')
+      It should works as same as gita#utils#ensure_pathlist in non Windows or without +shellslash
+        let pathlist = [
+              \ 'C:/Foo/Bar/Hoge.txt',
+              \ 'Piyo.txt',
+              \ '%',
+              \]
+        let ret = gita#utils#ensure_realpathlist(pathlist)
+        let exp = gita#utils#ensure_pathlist(pathlist)
+        Assert Equals(ret, exp)
+      End
+    else
+      Before
+        let saved_shellslash = &shellslash
+      End
+      After
+        let &shellslash = saved_shellslash
+      End
+
+      It should works as same as gita#utils#ensure_pathlist in Windows if shellslash is specified
+        set shellslash
+        let pathlist = [
+              \ 'C:/Foo/Bar/Hoge.txt',
+              \ 'Piyo.txt',
+              \ '%',
+              \]
+        let ret = gita#utils#ensure_realpathlist(pathlist)
+        let exp = gita#utils#ensure_pathlist(pathlist)
+        Assert Equals(ret, exp)
+      End
+
+      It should return a modified version of gita#utils#ensure_pathlist in Windows if noshellslash is specified
+        set noshellslash
+        let pathlist = [
+              \ 'C:/Foo/Bar/Hoge.txt',
+              \ 'Piyo.txt',
+              \ '%',
+              \]
+        let ret = gita#utils#ensure_realpathlist(pathlist)
+        let exp = gita#utils#ensure_pathlist(pathlist)
+        Assert NotEquals(ret, exp)
+        Assert Equals(ret, map(exp, 'fnamemodify(v:val, '':g?/?\\?'')'))
+      End
+    endif
+  End
+
+End


### PR DESCRIPTION
To fix #40. While I don't have Windows, need your help to fix this issue!
#### How to do unit tests

**It is not requried but better.**

First of all, vim-gita use [themis.vim](https://github.com/thinca/vim-themis) to test all its features.
So please follow the [instruction](https://github.com/thinca/vim-themis/blob/master/doc/themis.txt#L57) of themis.vim to test vim-gita. (Never mind 13 tests in `Pending`, these tests cannot be performed as unit test).
#### How to do behavior tests

vim-gita have a lot of features which cannot be tested via unit test.
the following commands required to be manually tests (everything should be performed under a root directory of a git repository of vim-gita)
At least, `:Gita file HEAD autoload\gita.vim` and `:Gita browse` is required.
**Please check the following when you confirm the command success**, otherwise please paste the exception. You may like [Capture.vim](https://github.com/tyru/capture.vim) which capture the output of Ex command and create a new buffer so you can easily copy & paste.
- [x] `:Gita add` on untracked files
- [x] **`:Gita browse` on `autoload\gita.vim`**
- [x] `:Gita checkout HEAD autoload\gita.vim`
- [x] `:Gita commit` after you stage changes
- [x] `:Gita commit` to actual commit
- [x] `:Gita diff HEAD~50` on `autoload\gita.vim`
- [x] `:Gita diff HEAD~50 --window=double` on `autoload\gita.vim`
- [x] `:Gita diff-ls origin/HEAD`
- [x] **`:Gita file HEAD autoload\gita.vim`**
- [x] `:Gita reset HEAD -- autoload\gita.vim`
- [x] `:Gita rm autoload\gita.vim`
- [x] `:Gita status` after you edit something

Thanks for your great cooperations !
