### PR TITLE
Windows: `Gita ls-files` not work

### DIFF
--- a/autoload/gita/meta.vim
+++ b/autoload/gita/meta.vim
@@ -53,7 +53,7 @@ function! gita#meta#expand(expr) abort
   endif
   let meta_filename = gita#meta#get('filename', '', a:expr)
   if s:Prelude.is_string(a:expr)
-    let real_filename = expand(a:expr . ':p')
+    let real_filename = s:Path.unixpath(expand(a:expr . ':p'))
     let real_filename = real_filename ==# a:expr . ':p'
           \ ? a:expr
           \ : real_filename


### PR DESCRIPTION
## Summary

`expand()` uses '\' as a path separater at `set noshellslash` on Windows.
