### PR TITLE
Fix description for `branch:delete` and `branch:delete:force`

### DIFF
--- a/autoload/gita/action/branch.vim
+++ b/autoload/gita/action/branch.vim
@@ -116,13 +116,13 @@ function! gita#action#branch#define(disable_mapping) abort
         \ 'options': { 'force': 1 },
         \})
   call gita#action#define('branch:delete', function('s:action_delete'), {
-        \ 'description': 'Rename a branch',
+        \ 'description': 'Delete a branch',
         \ 'mapping_mode': 'n',
         \ 'requirements': ['name'],
         \ 'options': {},
         \})
   call gita#action#define('branch:delete:force', function('s:action_delete'), {
-        \ 'description': 'Rename a branch',
+        \ 'description': 'Delete a branch',
         \ 'mapping_mode': 'n',
         \ 'requirements': ['name'],
         \ 'options': { 'force': 1 },


### PR DESCRIPTION
## Summary (required)

These descriptions should be for `branch:delete` or `branch:delete:force`.
