### PR TITLE
Respecting `cursorline` and `spell` settings by user(check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ You may notice that this behavior is quite useful when you temporary open a file
 
 Additionally, gita aggressively uses cache mechanisms to improve its' performance. You would notice huge performance improvement if you are currently using `system()` to show git repository informations in statusline such as a current branch name or the number of modified files.
 
-Do you like it? Buy me a coffee ;-)
-
-<a href="https://flattr.com/submit/auto?fid=6p91jn&url=https%3A%2F%2Fgithub.com%2Flambdalisue%2Fvim-gita" target="_blank">
-    <img src="https://button.flattr.com/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0">
-</a>
-
 Install
 -------------------------------------------------------------------------------
 Use your favorite Vim plugin manager such as [junegunn/vim-plug] or [Shougo/dein.vim] like:

--- a/autoload/gita/content/branch.vim
+++ b/autoload/gita/content/branch.vim
@@ -95,7 +95,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-branch
   setlocal buftype=nofile nobuflisted
-  setlocal nohidden
+  setlocal bufhidden=wipe
   setlocal nomodifiable
   call gita#content#branch#redraw()
   call gita#util#doautocmd('BufReadPost')

--- a/autoload/gita/content/chaperone.vim
+++ b/autoload/gita/content/chaperone.vim
@@ -8,6 +8,7 @@ function! s:open1(options) abort
 endfunction
 
 function! s:open2(options) abort
+  silent windo diffoff
   let options = extend({
         \ 'filename': '',
         \ 'opener': '',
@@ -48,6 +49,7 @@ function! s:open2(options) abort
 endfunction
 
 function! s:open3(options) abort
+  silent windo diffoff
   let options = extend({
         \ 'filename': '',
         \ 'opener': 'tabedit',

--- a/autoload/gita/content/commit.vim
+++ b/autoload/gita/content/commit.vim
@@ -205,7 +205,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-commit
   setlocal buftype=acwrite nobuflisted
-  setlocal modifiable
+  setlocal modifiable nomodeline
   call gita#content#commit#redraw()
   call gita#util#doautocmd('BufReadPost')
 endfunction

--- a/autoload/gita/content/diff.vim
+++ b/autoload/gita/content/diff.vim
@@ -230,6 +230,7 @@ function! s:on_FileWriteCmd(options) abort
 endfunction
 
 function! s:open1(options) abort
+  silent windo diffoff
   let options = extend({
         \ 'opener': '',
         \ 'window': '',
@@ -245,6 +246,7 @@ function! s:open1(options) abort
 endfunction
 
 function! s:open2(options) abort
+  silent windo diffoff
   let options = extend({
         \ 'patch': 0,
         \ 'cached': 0,

--- a/autoload/gita/content/diff.vim
+++ b/autoload/gita/content/diff.vim
@@ -230,7 +230,6 @@ function! s:on_FileWriteCmd(options) abort
 endfunction
 
 function! s:open1(options) abort
-  silent windo diffoff
   let options = extend({
         \ 'opener': '',
         \ 'window': '',

--- a/autoload/gita/content/diff_ls.vim
+++ b/autoload/gita/content/diff_ls.vim
@@ -157,7 +157,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-diff-ls
   setlocal buftype=nofile nobuflisted
-  setlocal nohidden
+  setlocal bufhidden=wipe
   setlocal nomodifiable
   call gita#content#diff_ls#redraw()
   call gita#util#doautocmd('BufReadPost')

--- a/autoload/gita/content/grep.vim
+++ b/autoload/gita/content/grep.vim
@@ -152,7 +152,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-grep
   setlocal buftype=nofile nobuflisted
-  setlocal nohidden
+  setlocal bufhidden=wipe
   setlocal nomodifiable
   call gita#content#grep#redraw()
   call gita#util#doautocmd('BufReadPost')

--- a/autoload/gita/content/grep.vim
+++ b/autoload/gita/content/grep.vim
@@ -202,6 +202,6 @@ function! gita#content#grep#autocmd(name, bufinfo) abort
 endfunction
 
 call gita#define_variables('content#grep', {
-      \ 'primary_action_mapping': '<Plug>(gita-show)',
+      \ 'primary_action_mapping': '<Plug>(gita-edit)',
       \ 'disable_default_mappings': 0,
       \})

--- a/autoload/gita/content/ls_files.vim
+++ b/autoload/gita/content/ls_files.vim
@@ -119,7 +119,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-ls-files
   setlocal buftype=nofile nobuflisted
-  setlocal nohidden
+  setlocal bufhidden=wipe
   setlocal nomodifiable
   call gita#content#ls_files#redraw()
   call gita#util#doautocmd('BufReadPost')

--- a/autoload/gita/content/ls_tree.vim
+++ b/autoload/gita/content/ls_tree.vim
@@ -93,7 +93,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-ls-tree
   setlocal buftype=nofile nobuflisted
-  setlocal nohidden
+  setlocal bufhidden=wipe
   setlocal nomodifiable
   call gita#content#ls_tree#redraw()
   call gita#util#doautocmd('BufReadPost')

--- a/autoload/gita/content/patch.vim
+++ b/autoload/gita/content/patch.vim
@@ -15,6 +15,7 @@ function! s:open1(options) abort
 endfunction
 
 function! s:open2(options) abort
+  silent windo diffoff
   let options = extend({
         \ 'reverse': 0,
         \ 'filename': '',
@@ -55,6 +56,7 @@ function! s:open2(options) abort
 endfunction
 
 function! s:open3(options) abort
+  silent windo diffoff
   let options = extend({
         \ 'filename': '',
         \ 'opener': 'tabedit',

--- a/autoload/gita/content/status.vim
+++ b/autoload/gita/content/status.vim
@@ -113,7 +113,7 @@ function! s:on_BufReadCmd(options) abort
   " the following options are required so overwrite everytime
   setlocal filetype=gita-status
   setlocal buftype=nofile nobuflisted
-  setlocal nohidden
+  setlocal bufhidden=wipe
   setlocal nomodifiable
   call gita#content#status#redraw()
   call gita#util#doautocmd('BufReadPost')

--- a/ftplugin/gita-branch.vim
+++ b/ftplugin/gita-branch.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0

--- a/ftplugin/gita-commit.vim
+++ b/ftplugin/gita-commit.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0

--- a/ftplugin/gita-diff-ls.vim
+++ b/ftplugin/gita-diff-ls.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0

--- a/ftplugin/gita-grep.vim
+++ b/ftplugin/gita-grep.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0

--- a/ftplugin/gita-ls-files.vim
+++ b/ftplugin/gita-ls-files.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0

--- a/ftplugin/gita-ls-tree.vim
+++ b/ftplugin/gita-ls-tree.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0

--- a/ftplugin/gita-status.vim
+++ b/ftplugin/gita-status.vim
@@ -4,7 +4,12 @@ endif
 let b:did_ftplugin = 1
 
 setlocal winfixheight
-setlocal cursorline
-setlocal nolist nospell
+if &cursorline
+  setlocal cursorline
+endif
+if !&spell
+  setlocal nospell
+endif
+setlocal nolist 
 setlocal nowrap nofoldenable
 setlocal foldcolumn=0 colorcolumn=0


### PR DESCRIPTION
Non-native English speakers sometimes enable spell checking in the vim while configuring a commit message. This fix will take into account their `vimrc` settings for composing commit messages using Gita. Also, some people really don't like cursorline in vim. This is to avoid that aesthetic damage.

