### PR TITLE
Add diffget keymap for worktree

### DIFF
--- a/autoload/gita/content/patch.vim
+++ b/autoload/gita/content/patch.vim
@@ -118,8 +118,13 @@ function! s:open3(options) abort
         \ 'nnoremap <silent><buffer> <Plug>(gita-diffput) :diffput %d<BAR>diffupdate<CR>',
         \ chs_bufnum,
         \)
+  execute printf(
+        \ 'nnoremap <silent><buffer> <Plug>(gita-diffget) :diffget %d<BAR>diffupdate<CR>',
+        \ chs_bufnum,
+        \)
   if !g:gita#content#patch#disable_default_mappings
     nmap <buffer> dp <Plug>(gita-diffput)
+    nmap <buffer> do <Plug>(gita-diffget)
   endif
 
   execute printf('keepjumps %dwincmd w', bufwinnr(chs_bufnum))


### PR DESCRIPTION
## Summary (required)

In 2-way diff, Working tree can be reverted partially to Index by `do` or `dp`. It is useful to clean unneeded code.    
But in 3-way diff, there is no keymap to make Worktree diffget from Index. This PR add `do` keymap to realize it.
